### PR TITLE
And/Or Merging Queryset Logic

### DIFF
--- a/django_mock_queries/query.py
+++ b/django_mock_queries/query.py
@@ -38,12 +38,15 @@ class MockSet(MagicMock):
         self.clone = clone
         self.model = getattr(clone, 'model', model)
         self.events = {}
+        self.filter_obj = kwargs.pop('filter_obj', DjangoQ())
 
         self.add(*initial_items)
 
         self.__len__ = lambda s: len(s.items)
         self.__iter__ = lambda s: iter(s.items)
         self.__getitem__ = lambda s, k: self.items[k]
+        self.__and__ = self.and_
+        self.__or__ = self.or_
 
     def _return_self(self, *_, **__):
         return self
@@ -78,6 +81,21 @@ class MockSet(MagicMock):
             self.items.append(model)
             self.fire(model, self.EVENT_ADDED, self.EVENT_SAVED)
 
+    def and_(self, source, other):
+        if source.items == 0:
+            return source
+        if other.items == 0:
+            return other
+        return self.filter(source.filter_obj & other.filter_obj)
+
+    def or_(self, source, other):
+        if source.items == 0:
+            return other
+        if other.items == 0:
+            return source
+        self.items = list(set(self.items) | (set(other.items)))
+        return self.filter(source.filter_obj | other.filter_obj)
+
     def _filter_single_q(self, source, q_obj, negated):
         if isinstance(q_obj, DjangoQ):
             return self._filter_q(source, q_obj)
@@ -102,12 +120,17 @@ class MockSet(MagicMock):
 
     def filter(self, *args, **attrs):
         results = list(self.items)
+        new_filter_object = None
         for x in args:
             if isinstance(x, DjangoQ):
                 results = self._filter_q(results, x)
+                if new_filter_object:
+                    new_filter_object &= x
+                else:
+                    new_filter_object = x
             else:
                 raise ArgumentNotSupported()
-        return MockSet(*matches(*results, **attrs), clone=self)
+        return MockSet(*matches(*results, **attrs), clone=self, filter_obj=new_filter_object)
 
     def exclude(self, *args, **attrs):
         excluded = self.filter(*args, **attrs)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1213,7 +1213,6 @@ class TestQuery(TestCase):
         results = [str(x) for x in test_qs]
         assert results == expected_results
 
-
     def test_and_merge_queryset(self):
         qs = MockSet(
             MockModel(mock_name='model-1', foo='A', bar='1'),

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1199,3 +1199,30 @@ class TestQuery(TestCase):
         assert len(result) == 2
         assert result[0] == datetime.datetime(2017, 1, 10, 1, 2, 9)
         assert result[1] == datetime.datetime(2017, 1, 10, 1, 2, 3)
+
+    def test_or_merge_queryset(self):
+        qs = MockSet(
+            MockModel(mock_name='model-1', foo='A', bar='1'),
+            MockModel(mock_name='model-2', foo='B', bar='2'),
+            MockModel(mock_name='model-3', foo='C', bar='3'),
+        )
+
+        test_qs = qs.all().filter(Q(foo='A'))
+        test_qs |= qs.all().filter(Q(bar='2'))
+        expected_results = ['model-1', 'model-2']
+        results = [str(x) for x in test_qs]
+        assert results == expected_results
+
+
+    def test_and_merge_queryset(self):
+        qs = MockSet(
+            MockModel(mock_name='model-1', foo='A', bar='1'),
+            MockModel(mock_name='model-2', foo='B', bar='1'),
+            MockModel(mock_name='model-3', foo='C', bar='3'),
+        )
+
+        test_qs = qs.all().filter(Q(foo='A'))
+        test_qs &= test_qs.all().filter(Q(bar='1'))
+        expected_results = ['model-1']
+        results = [str(x) for x in test_qs]
+        assert results == expected_results


### PR DESCRIPTION
* Allows querysets to be merged via `&` or `|`